### PR TITLE
packagedown 문서의 articles/introduction.html에서 "CO2_emissions" 데이터셋의 헤더…

### DIFF
--- a/docs/articles/introduction.html
+++ b/docs/articles/introduction.html
@@ -82,7 +82,7 @@
 
       
 
-      </header><script src="introduction_files/header-attrs-2.10/header-attrs.js"></script><div class="row">
+      </header><script src="introduction_files/header-attrs-2.8/header-attrs.js"></script><div class="row">
   <div class="col-md-9 contents">
     <div class="page-header toc-ignore">
       <h1 data-toc-skip>introduction</h1>
@@ -98,10 +98,9 @@
 <div id="setup" class="section level1">
 <h1 class="hasAnchor">
 <a href="#setup" class="anchor"></a>Setup</h1>
-<p>Once the package has been installed, simply type <code><a href="https://rdrr.io/r/base/library.html">library(statdata)</a></code> as ususal.</p>
-<div class="sourceCode" id="cb1"><pre class="downlit sourceCode r">
-<code class="sourceCode R"><span class="co"># library(tidyverse)</span>
-<span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span><span class="op">(</span><span class="va">statdata</span><span class="op">)</span></code></pre></div>
+<p>Once the package has been installed, simply type <code><a href="https://rdrr.io/pkg/statdata/man">library(statdata)</a></code> as ususal.</p>
+<div class="sourceCode" id="cb1"><html><body><pre class="r"><span class="co"># library(tidyverse)</span>
+<span class="fu"><a href="https://rdrr.io/r/base/library.html">library</a></span>(<span class="no">statdata</span>)</pre></body></html></div>
 </div>
 <div id="data-dictionary" class="section level1">
 <h1 class="hasAnchor">
@@ -112,31 +111,19 @@
 <h1 class="hasAnchor">
 <a href="#basic-usage" class="anchor"></a>Basic Usage</h1>
 <p>This package contains the simple, but valuable datasets to understand basic data science concepts. While looking into datasets, mostly dataframe (aka, tibble), you can apply statistical skills which you have learned.</p>
-<div class="sourceCode" id="cb2"><pre class="downlit sourceCode r">
-<code class="sourceCode R"><span class="fu"><a href="https://rdrr.io/r/utils/data.html">data</a></span><span class="op">(</span><span class="st">"CO2_emissions"</span><span class="op">)</span>
-<span class="va">CO2_emissions</span>
-<span class="co">#&gt;    \xb1\xb9\xb0\xa1 \xc0̻\xeaȭź\xbc\u04b9\xe8\xc3ⷮ \xbc\xf8\xc0\xa7</span>
-<span class="co">#&gt; 1              중국                       7706.8               76</span>
-<span class="co">#&gt; 2              미국                       5424.5               16</span>
-<span class="co">#&gt; 3              인도                       1591.1              144</span>
-<span class="co">#&gt; 4            러시아                       1556.7               35</span>
-<span class="co">#&gt; 5              일본                       1098.0               54</span>
-<span class="co">#&gt; 6              독일                        765.6               45</span>
-<span class="co">#&gt; 7            캐나다                        541.0               20</span>
-<span class="co">#&gt; 8              이란                        528.6               65</span>
-<span class="co">#&gt; 9          대한민국                        528.1               36</span>
-<span class="co">#&gt; 10             영국                        512.0               58</span>
-<span class="co">#&gt;    1\xc0\u03b4\xe7\xb9\xe8\xc3ⷮ</span>
-<span class="co">#&gt; 1                          5.8</span>
-<span class="co">#&gt; 2                         17.7</span>
-<span class="co">#&gt; 3                          1.4</span>
-<span class="co">#&gt; 4                         11.1</span>
-<span class="co">#&gt; 5                          8.6</span>
-<span class="co">#&gt; 6                          9.3</span>
-<span class="co">#&gt; 7                         16.2</span>
-<span class="co">#&gt; 8                          7.0</span>
-<span class="co">#&gt; 9                         10.9</span>
-<span class="co">#&gt; 10                         8.4</span></code></pre></div>
+<div class="sourceCode" id="cb2"><html><body><pre class="r"><span class="fu"><a href="https://rdrr.io/r/utils/data.html">data</a></span>(<span class="st">"CO2_emissions"</span>)
+<span class="no">CO2_emissions</span>
+<span class="co">#&gt;        국가 이산화탄소배출량 순위 1인당배출량</span>
+<span class="co">#&gt; 1      중국           7706.8   76         5.8</span>
+<span class="co">#&gt; 2      미국           5424.5   16        17.7</span>
+<span class="co">#&gt; 3      인도           1591.1  144         1.4</span>
+<span class="co">#&gt; 4    러시아           1556.7   35        11.1</span>
+<span class="co">#&gt; 5      일본           1098.0   54         8.6</span>
+<span class="co">#&gt; 6      독일            765.6   45         9.3</span>
+<span class="co">#&gt; 7    캐나다            541.0   20        16.2</span>
+<span class="co">#&gt; 8      이란            528.6   65         7.0</span>
+<span class="co">#&gt; 9  대한민국            528.1   36        10.9</span>
+<span class="co">#&gt; 10     영국            512.0   58         8.4</span></pre></body></html></div>
 </div>
   </div>
 
@@ -155,7 +142,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.6.1.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
 </div>
 
       </footer>


### PR DESCRIPTION
packagedown 문서의 articles/introduction.html에서 "CO2_emissions" 데이터셋의 헤더 한글이 깨진 것을  수정했습니다.

제 맥에서  packagedown 문서를 빌드했을 경우에는 데이터셋 헤더의 한글이 깨지지 않더군요.
아마도 빌드 환경에 따라 다소 차이가 나는 것 같습니다.

한글의 경우에는 운영체제 및 환경에 따라 차이가 많이 나서, 멀티 플랫폼 개발 환경에서 불필요한 노가다가 발생하네요. 